### PR TITLE
Fix link to DO docs app platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ As long as you left the default Autodeploy option enabled when you first launche
 
 ## Learn More ##
 
-You can learn more about the App Platform and how to manage and update your application at https://www.digitalocean.com/docs/apps/.
+You can learn more about the App Platform and how to manage and update your application at https://www.digitalocean.com/docs/app-platform/.
 
 
 ## Deleting the App #


### PR DESCRIPTION
Changed broken link in README from /docs/apps to /docs/app-platform