### PR TITLE
Add support for setting timezone using environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,12 @@ RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 # Copy the binary from the builder stage and set it as the default command.
 COPY --from=builder /app/bin/hello /usr/local/bin/
+
+# You can set timezone for your container by setting TZ environment variable.
+# More details https://docs.digitalocean.com/products/app-platform/reference/dockerfile/#environment-variables
+ARG TZ
+
+# Set timezone as an environment variable for run-time
+ENV TZ=${TZ}
+
 CMD ["hello"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY --from=builder /app/bin/hello /usr/local/bin/
 
 # You can set timezone for your container by setting TZ environment variable.
 # More details https://docs.digitalocean.com/products/app-platform/reference/dockerfile/#environment-variables
+# Default timezone is UTC
 ARG TZ
 
 # Set timezone as an environment variable for run-time


### PR DESCRIPTION
For dockerfile based images, setting only `TZ` in environment variables list from the cloud control panel is not enough. This PR adds and support for TZ so simply adding `TZ` environment variable works as expected.